### PR TITLE
Only set pre_tag to initial version if no previous was found

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -62,7 +62,10 @@ if [ -z "$tag" ]
 then
     log=$(git log --pretty='%B')
     tag="$initial_version"
-    pre_tag="$initial_version"
+    if [ -z "$pre_tag" ]
+    then
+      pre_tag="$initial_version"
+    fi
 else
     log=$(git log $tag..HEAD --pretty='%B')
 fi


### PR DESCRIPTION
Bugfix -> Constantly tried to bump to the same prerelease. Allows for proper iteration. 